### PR TITLE
[bug: DE26731] rhapsody.js: Add gulp related packages in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,8 @@
   "dependencies": {},
   "devDependencies": {
     "gulp": "^3.8.6",
+    "gulp-concat": "^2.6.0",
+    "gulp-plumber": "^1.1.0",
     "gulp-uglifyjs": "^0.4.2"
   },
   "scripts": {


### PR DESCRIPTION
https://rally1.rallydev.com/#/24755394555d/detail/defect/54026268327

Fixes errors when you run `gulp build`